### PR TITLE
Rewrite the assnouncer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,183 @@
-.vscode
-theme_db
-streamcache
+themes/
+downloads/
 token
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+
+# End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Assnouncer",
+            "type": "python",
+            "request": "launch",
+            "program": "assnouncer.py",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        }
+    ]
+}

--- a/assnouncer.py
+++ b/assnouncer.py
@@ -70,15 +70,17 @@ class Assnouncer(Client):
         while True:
             while self.is_playing():
                 if len(self.queue) > 1:
-                    await util.download(self.queue[1])
+                    uri = self.queue[1]
+                    await util.download(uri)
                 await sleep(0.1)
 
             while not self.queue:
                 await sleep(0.3)
 
-            song = await util.download(self.queue[0])
+            uri = self.queue[0]
 
-            await self.message(f"Playing '{song.uri}'")
+            await self.message(f"Playing '{uri}'")
+            song = await util.download(uri)
 
             if song.source is not None:
                 self.voice.play(song.source, after=pop)
@@ -101,7 +103,7 @@ class Assnouncer(Client):
         return await self.song_loop()
 
     def queue_song(self, query: str):
-        self.queue.append(query)
+        self.queue.append(util.resolve_uri(query))
 
     async def play_theme(self, user: Member):
         theme_path = util.get_theme_path(user)

--- a/assnouncer.py
+++ b/assnouncer.py
@@ -8,6 +8,7 @@ from asyncio.tasks import sleep
 from typing import List
 from pathlib import Path
 from commands import BaseCommand
+from commandline import Timestamp
 from discord.player import AudioPlayer
 from discord import (
     Client, Game, FFmpegOpusAudio, TextChannel,
@@ -108,7 +109,17 @@ class Assnouncer(Client):
         self.voice = await self.server.voice_channels[0].connect(timeout=2000, reconnect=True)
 
         await self.set_activity("Ready")
+
         print("[info] Ready")
+
+        main_theme = await util.download(
+            SongRequest(
+                query="https://www.youtube.com/watch?v=atuFSv2bLa8",
+                start=Timestamp.parse("00:19"),
+                stop=Timestamp.parse("00:23")
+            )
+        )
+        await self.play_now(main_theme.source)
 
         return await self.song_loop()
 

--- a/assnouncer.py
+++ b/assnouncer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import util
 
-from util import LoadedSong, SongRequest
+from util import SongRequest
 from dataclasses import dataclass, field
 from asyncio.tasks import sleep
 from typing import List

--- a/assnouncer.py
+++ b/assnouncer.py
@@ -84,6 +84,7 @@ class Assnouncer(Client):
                 self.voice.play(song.source, after=pop)
             else:
                 print(f"[warn] No source found for '{song.uri}'")
+                pop()
                 await self.message(f"No source found - skipping song")
 
     async def on_ready(self):

--- a/assnouncer.py
+++ b/assnouncer.py
@@ -2,23 +2,14 @@ from __future__ import annotations
 
 import util
 
+from util import LoadedSong
 from dataclasses import dataclass, field
 from asyncio.tasks import sleep
-from typing import Any, List
+from typing import List
 from pathlib import Path
 from discord.player import AudioPlayer
 from discord import Client, Game, FFmpegOpusAudio, TextChannel, Message, Guild, VoiceClient, Member, VoiceState
-
-from pytube import YouTube, Search
-
 from commands import BaseCommand
-from downloaders import BaseDownloader
-
-
-@dataclass
-class LoadedSong:
-    uri: str
-    source: FFmpegOpusAudio
 
 
 @dataclass
@@ -31,39 +22,31 @@ class Assnouncer(Client):
     def __post_init__(self):
         super().__init__()
 
-    @staticmethod
-    def search_song(query: str) -> str:
-        results: List[YouTube]
-        results, _ = Search(query).fetch_and_parse()
-        if results:
-            return results[0].watch_url
-
     def is_playing(self) -> bool:
         return self.voice.is_playing()
 
     def skip(self):
-        self.voice.stop
+        self.voice.stop()
 
     def stop(self):
         self.queue = []
         self.skip()
 
     async def play_now(self, source: FFmpegOpusAudio):
-        vc: VoiceClient = self.voice
-        if vc.is_playing():
-            old_source: AudioPlayer = gg.voice._player
+        if self.voice.is_playing():
+            old_source: AudioPlayer = self.voice._player
             old_source.pause()
 
-            vc._player = None
-            vc.play(source)
-            while vc.is_playing():
+            self.voice._player = None
+            self.voice.play(source)
+            while self.voice.is_playing():
                 await sleep(0.3)
-            vc.stop()
+            self.voice.stop()
 
-            vc._player = old_source
-            vc.resume()
+            self.voice._player = old_source
+            self.voice.resume()
         else:
-            vc.play(source)
+            self.voice.play(source)
 
     def set_activity(self, activity: str):
         return self.change_presence(activity=Game(name=activity))
@@ -74,35 +57,10 @@ class Assnouncer(Client):
 
         return channel.send(message)
 
-    async def download_song(self, uri: str) -> FFmpegOpusAudio:
-        downloaders = BaseDownloader.get_instances()
-        if all(not downloader.accept(uri) for downloader in downloaders):
-            uri = Assnouncer.search_song(uri)
-
-        filename = util.get_download_path(uri)
-
-        async def load_song():
-
-            return LoadedSong(
-                uri=uri,
-                source=await util.load_source(filename)
-            )
-
-        if filename.is_file():
-            return await load_song()
-
-        for downloader in downloaders:
-            if downloader.accept(uri):
-                print(f"[info] Downloading via {downloader.__name__}")
-                if downloader.download(uri, filename):
-                    break
-
-        return await load_song()
-
     async def download_from_queue(self, idx: int) -> LoadedSong:
         if len(self.queue) > idx:
             uri = self.queue[idx]
-            return await self.download_song(uri)
+            return await util.download(uri)
 
     async def song_loop(self):
         def pop(*_):
@@ -112,13 +70,13 @@ class Assnouncer(Client):
         while True:
             while self.is_playing():
                 if len(self.queue) > 1:
-                    await self.download_from_queue(1)
+                    await util.download(self.queue[1])
                 await sleep(0.1)
 
             while not self.queue:
                 await sleep(0.3)
 
-            song = await self.download_from_queue(0)
+            song = await util.download(self.queue[0])
 
             await self.message(f"Playing '{song.uri}'")
 
@@ -144,7 +102,7 @@ class Assnouncer(Client):
     def queue_song(self, query: str):
         self.queue.append(query)
 
-    async def play_theme(self, user: str):
+    async def play_theme(self, user: Member):
         theme_path = util.get_theme_path(user)
         new_source = util.load_source(theme_path)
 
@@ -165,15 +123,15 @@ class Assnouncer(Client):
         prev_channel = before.channel
         next_channel = after.channel
         if prev_channel is None and next_channel is not None:
-            print(f"[chat] <{next_channel.name}: {member} has joined")
-            await self.play_theme(f"{member.name}#{member.discriminator}")
+            print(f"[chat] <{next_channel.name}>: {member} has joined")
+            await self.play_theme(member)
 
     async def on_message(self, message: Message):
         if self.voice is None:
             return
 
         for command in BaseCommand.get_instances():
-            command_args = command.parse(message.content)
+            command_args = command.parse(message)
             if command_args is not None:
                 print(f"[info] Received {command.__name__}")
                 await command.on_command(self, command_args)

--- a/commandline.py
+++ b/commandline.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import ast
+import regex
+
+from regex import VERSION1
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Tuple, Match, TypeVar, Type, Callable
+
+T = TypeVar("T")
+
+
+class TokenType(Enum):
+    COMMA = ","
+    EQUAL = "="
+    OPEN_BRACE = "\\["
+    CLOSE_BRACE = "\\]"
+    TIMESTAMP = "\\d+:\\d+"
+    NUMBER = "\\d+(?:\\.\\d+)?"
+    IDENTIFIER = "\\w+"
+    STRING = "\"(?:[^\\\\\"]|(?:\\\\.))*\""
+    BULLSHIT = "\\S+"
+
+
+@dataclass(unsafe_hash=True)
+class Token:
+    start: int
+    stop: int
+    text: str
+    type: TokenType
+
+
+@dataclass(unsafe_hash=True)
+class Value:
+    text: str
+
+    @classmethod
+    def parse(cls: T, text: str) -> T:
+        pass
+
+
+@dataclass(unsafe_hash=True)
+class Number(Value):
+    value: float
+
+    @staticmethod
+    def parse(text: str) -> Number:
+        return Number(
+            value=float(text),
+            text=text
+        )
+
+
+@dataclass(unsafe_hash=True)
+class Identifier(Value):
+    value: str
+
+    @staticmethod
+    def parse(text: str) -> Identifier:
+        return Identifier(
+            value=text,
+            text=text
+        )
+
+
+@dataclass(unsafe_hash=True)
+class String(Value):
+    value: str
+
+    @staticmethod
+    def parse(text: str) -> String:
+        return String(
+            value=ast.literal_eval(text),
+            text=text
+        )
+
+
+@dataclass(unsafe_hash=True)
+class Timestamp(Value):
+    value: int
+    minutes: int
+    seconds: int
+
+    @staticmethod
+    def parse(text: str) -> Timestamp:
+        minutes, seconds = text.split(":")
+        minutes, seconds = int(minutes), int(seconds)
+
+        return Timestamp(
+            value=minutes * 60 + seconds,
+            minutes=minutes,
+            seconds=seconds,
+            text=text
+        )
+
+
+@dataclass
+class Command:
+    name: Identifier
+    args: List[Value]
+    kwargs: Dict[str, Value]
+    payload: str = None
+
+
+def make_token(match: Match):
+    start = match.start()
+    stop = match.end()
+    for key, value in match.groupdict().items():
+        if value is not None:
+            return Token(
+                start=start,
+                stop=stop,
+                text=value,
+                type=TokenType[key]
+            )
+
+
+def tokenize(text: str) -> List[Token]:
+    regexes = [f"(?P<{type.name}>{type.value})" for type in TokenType]
+    gigaregex = "|".join(regexes)
+
+    return list(map(make_token, regex.finditer(gigaregex, text, flags=VERSION1)))
+
+
+def find(tokens: List[Token], type: TokenType) -> int:
+    copy = tokens.copy()
+    while copy and copy[0].type is not type:
+        copy.pop(0)
+
+    idx = len(tokens) - len(copy)
+    if idx == 0:
+        return None
+
+    return idx
+
+
+def parse_split(tokens: List[Token], separator: TokenType) -> List[List[Token]]:
+    splits = []
+
+    split = []
+    while tokens:
+        token = tokens.pop(0)
+
+        if token.type is separator:
+            splits.append(split)
+            split = []
+        else:
+            split.append(token)
+
+    if split:
+        splits.append(split)
+
+    return splits
+
+
+def parse_arg(tokens: List[Token]) -> Value:
+    if len(tokens) != 1:
+        return None
+
+    map: Dict[TokenType, Type[Value]] = {
+        TokenType.IDENTIFIER: Identifier,
+        TokenType.NUMBER: Number,
+        TokenType.STRING: String,
+        TokenType.TIMESTAMP: Timestamp
+    }
+
+    first, = tokens
+    if first.type in map:
+        return map[first.type].parse(first.text)
+
+
+def parse_kwarg(tokens: List[Token]) -> Tuple[Identifier, Value]:
+    if len(tokens) != 3:
+        return None
+
+    first, second, third = tokens
+    if first.type is not TokenType.IDENTIFIER:
+        return None
+
+    if second.type is not TokenType.EQUAL:
+        return None
+
+    key = first.text
+    value = parse_arg([third])
+    if value is not None:
+        return key, value
+
+
+def parse(text: str) -> Command:
+    tokens = tokenize(text)
+
+    if not tokens:
+        raise SyntaxError("Empty input")
+
+    first = tokens[0]
+    if first.type is not TokenType.IDENTIFIER:
+        raise SyntaxError("Expected name")
+
+    name = Identifier.parse(first.text)
+
+    args = None
+    kwargs = None
+
+    tokens = tokens[1:]
+    if tokens:
+        first = tokens[0]
+        if first.type is TokenType.OPEN_BRACE:
+            idx = find(tokens, TokenType.CLOSE_BRACE)
+
+            if idx is None:
+                raise SyntaxError("Expected closing brace")
+
+            arglist_tokens = tokens[1:idx]
+            splits = parse_split(arglist_tokens, TokenType.COMMA)
+
+            args = [arg for arg in map(parse_arg, splits) if arg]
+            kwargs = [kwarg for kwarg in map(parse_kwarg, splits) if kwarg]
+
+            if len(args) + len(kwargs) != len(splits):
+                raise SyntaxError("Could not parse all arguments")
+
+            kwargs = {k: v for k, v in kwargs}
+
+            tokens = tokens[idx + 1:]
+
+    payload = None
+    if tokens:
+        payload = text[tokens[0].start:]
+
+    return Command(
+        name=name,
+        args=args,
+        kwargs=kwargs,
+        payload=payload
+    )

--- a/commands.py
+++ b/commands.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from metaclass import Descriptor
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List
+from enum import unique, IntEnum
+
+if TYPE_CHECKING:
+    from assnouncer import Assnouncer
+
+
+@unique
+class CommandType(IntEnum):
+    BEGIN = 0
+    EXACT = 1
+    END = 2
+
+
+@dataclass
+class CommandArgs:
+    parse_method: CommandType
+    keyword: str
+    argument: str = None
+
+
+class BaseCommand(metaclass=Descriptor):
+    KEYWORDS: List[str] = None
+    TYPE: CommandType = None
+
+    @classmethod
+    def parse(cls, content: str) -> CommandArgs:
+        for keyword in cls.KEYWORDS:
+            if cls.TYPE is CommandType.BEGIN:
+                if content.startswith(keyword):
+                    return CommandArgs(
+                        parse_method=cls.TYPE,
+                        keyword=keyword,
+                        argument=content[len(keyword):]
+                    )
+            elif cls.TYPE is CommandType.EXACT:
+                if content == keyword:
+                    return CommandArgs(
+                        parse_method=cls.TYPE,
+                        keyword=keyword
+                    )
+            elif cls.TYPE is CommandType.END:
+                if content.endswith(keyword):
+                    return CommandArgs(
+                        parse_method=cls.TYPE,
+                        keyword=keyword,
+                        argument=content[:-len(keyword)]
+                    )
+
+    @staticmethod
+    async def on_command(ass: Assnouncer, message: CommandArgs):
+        pass
+
+
+class PlayCommand(BaseCommand):
+    KEYWORDS: List[str] = ["play "]
+    TYPE: CommandType = CommandType.BEGIN
+
+    @staticmethod
+    async def on_command(ass: Assnouncer, message: CommandArgs):
+        ass.queue_song(message.argument)
+
+
+class QueueCommand  (BaseCommand):
+    KEYWORDS: List[str] = ["queue"]
+    TYPE: CommandType = CommandType.EXACT
+
+    @staticmethod
+    async def on_command(ass: Assnouncer, _: CommandArgs):
+        queue_content = "\n".join(f"{i}: {q}" for i, q in enumerate(ass.queue))
+        if not queue_content:
+            queue_content = "Queue is empty."
+        await ass.message(f"```{queue_content}```")
+
+
+class StopCommand(BaseCommand):
+    KEYWORDS: List[str] = [
+        "stop",
+        "dilyankata",
+        "не ме занимавай с твоите глупости"
+    ]
+    TYPE: CommandType = CommandType.EXACT
+
+    @staticmethod
+    async def on_command(ass: Assnouncer, _: CommandArgs):
+        ass.stop()
+
+        
+class NextCommand(BaseCommand):
+    KEYWORDS: List[str] = ["next", "skip", "маняк"]
+    TYPE: CommandType = CommandType.EXACT
+
+    @staticmethod
+    async def on_command(ass: Assnouncer, _: CommandArgs):
+        ass.skip()

--- a/commands.py
+++ b/commands.py
@@ -25,11 +25,25 @@ class CommandData:
     parse_method: CommandType
     keyword: str
     argument: str = None
+    payload: str = None
 
 
 class BaseCommand(metaclass=Descriptor):
-    KEYWORDS: List[str] = None
     TYPE: CommandType = None
+    KEYWORDS: List[str] = None
+
+    @classmethod
+    def validate(cls):
+        if cls == BaseCommand:
+            return
+
+        msg = "TYPE must be a CommandType"
+        assert isinstance(cls.TYPE, CommandType), msg
+
+        msg = "KEYWORDS must be a non-empty list of str"
+        assert cls.KEYWORDS, msg
+        assert isinstance(cls.KEYWORDS, list), msg
+        assert all(isinstance(k, str) for k in cls.KEYWORDS), msg
 
     @classmethod
     def parse(cls, message: Message) -> CommandData:
@@ -59,17 +73,17 @@ class BaseCommand(metaclass=Descriptor):
 
 
 class PlayCommand(BaseCommand):
-    KEYWORDS: List[str] = ["play "]
     TYPE: CommandType = CommandType.BEGIN
+    KEYWORDS: List[str] = ["play "]
 
     @staticmethod
     async def on_command(ass: Assnouncer, data: CommandData):
-        ass.queue_song(data.argument)
+        ass.queue_song(data.payload)
 
 
 class QueueCommand  (BaseCommand):
-    KEYWORDS: List[str] = ["queue"]
     TYPE: CommandType = CommandType.EXACT
+    KEYWORDS: List[str] = ["queue"]
 
     @staticmethod
     async def on_command(ass: Assnouncer, _: CommandData):
@@ -80,12 +94,12 @@ class QueueCommand  (BaseCommand):
 
 
 class StopCommand(BaseCommand):
+    TYPE: CommandType = CommandType.EXACT
     KEYWORDS: List[str] = [
         "stop",
         "dilyankata",
         "не ме занимавай с твоите глупости"
     ]
-    TYPE: CommandType = CommandType.EXACT
 
     @staticmethod
     async def on_command(ass: Assnouncer, _: CommandData):
@@ -93,8 +107,8 @@ class StopCommand(BaseCommand):
 
 
 class NextCommand(BaseCommand):
-    KEYWORDS: List[str] = ["next", "skip", "маняк"]
     TYPE: CommandType = CommandType.EXACT
+    KEYWORDS: List[str] = ["next", "skip", "маняк"]
 
     @staticmethod
     async def on_command(ass: Assnouncer, _: CommandData):
@@ -102,14 +116,14 @@ class NextCommand(BaseCommand):
 
 
 class SetThemeCommand(BaseCommand):
-    KEYWORDS: List[str] = ["set my theme ", "set theme "]
     TYPE: CommandType = CommandType.BEGIN
+    KEYWORDS: List[str] = ["set my theme ", "set theme "]
 
     @staticmethod
     async def on_command(_: Assnouncer, data: CommandData):
         author = data.message.author
         song = await util.download(
-            data.argument,
+            data.payload,
             filename=util.get_theme_path(author),
             force=True
         )

--- a/commands.py
+++ b/commands.py
@@ -49,23 +49,23 @@ class BaseCommand(metaclass=Descriptor):
     def parse(cls, message: Message) -> CommandData:
         content: str = message.content
         for keyword in cls.KEYWORDS:
-            def make_data(argument: str = None):
+            def make_data(payload: str = None):
                 return CommandData(
                     message=message,
                     parse_method=cls.TYPE,
                     keyword=keyword,
-                    argument=argument
+                    payload=payload
                 )
 
             if cls.TYPE is CommandType.BEGIN:
                 if content.startswith(keyword):
-                    return make_data(argument=content[len(keyword):])
+                    return make_data(payload=content[len(keyword):])
             elif cls.TYPE is CommandType.EXACT:
                 if content == keyword:
                     return make_data()
             elif cls.TYPE is CommandType.END:
                 if content.endswith(keyword):
-                    return make_data(argument=content[:-len(keyword)])
+                    return make_data(payload=content[:-len(keyword)])
 
     @staticmethod
     async def on_command(ass: Assnouncer, data: CommandData):

--- a/commands.py
+++ b/commands.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
-from sqlite3 import Timestamp
 
 import util
+import random
 import commandline
 
 from util import SongRequest
-from commandline import Command, Timestamp
+from commandline import Command, Timestamp, Identifier, String
 from metaclass import Descriptor
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Union
 from discord import Message
 
 if TYPE_CHECKING:
@@ -108,4 +108,43 @@ class SetThemeCommand(BaseCommand):
             filename=util.get_theme_path(author),
             force=True
         )
-        print(f"[info] Set theme for {author} to {song.uri}")
+        if song is not None:
+            print(f"[info] Set theme for {author} to {song.uri}")
+        else:
+            print(f"[warn] Could not set theme for {author}")
+
+
+class DumbCommand(BaseCommand):
+    ALIASES: List[str] = ["dumb", "мамкамуипрасе", "dumbdumb"]
+
+    @staticmethod
+    async def on_command(
+        ass: Assnouncer,
+        _: Message,
+        who: Union[Identifier, String],
+        payload: str = None,
+        howdumb: Union[Identifier, String] = None
+    ):
+        if howdumb is not None:
+            msg = f"{who.value} is {howdumb.value} dumb"
+        else:
+            msg = f"{who.value} is dumb"
+
+        await ass.message(msg)
+
+
+class ApricotCommand(BaseCommand):
+    ALIASES: List[str] = ["кайсий", "кайсии", "apricot"]
+
+    @staticmethod
+    async def on_command(
+        ass: Assnouncer,
+        _: Message,
+        payload: str = None
+    ):
+        memes = [
+            "https://memegenerator.net/img/instances/78370751.jpg",
+            "https://i.imgflip.com/1zcw47.jpg",
+            "https://www.memecreator.org/static/images/memes/4835791.jpg"
+        ]
+        await ass.message(random.choice(memes))

--- a/config.py
+++ b/config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+
+from pathlib import Path
+from typing import Any
+
+
+def env(k: str, d: Any = None):
+    return os.environ.get(k, d)
+
+
+HERE = Path(".")
+
+DOWNLOAD_DIR = HERE / "downloads"
+DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+THEMES_DIR = HERE / "themes"
+THEMES_DIR.mkdir(parents=True, exist_ok=True)
+
+TOKEN_PATH = HERE / "token"
+
+FFMPEG_DIR = Path(env("FFMPEG_DIR", "C:/Users/Admin/Documents/Applications/"))
+FFMPEG_PATH = FFMPEG_DIR / "ffmpeg.exe"

--- a/downloaders.py
+++ b/downloaders.py
@@ -7,11 +7,20 @@ from config import FFMPEG_DIR
 from metaclass import Descriptor
 from typing import List
 from pathlib import Path
-from sclib import SoundcloudAPI
 
 
 class BaseDownloader(metaclass=Descriptor):
     PATTERNS: List[str] = None
+
+    @classmethod
+    def validate(cls):
+        if cls == BaseDownloader:
+            return
+            
+        msg = "PATTERNS must be a non-empty list of str"
+        assert cls.PATTERNS, msg
+        assert isinstance(cls.PATTERNS, list), msg
+        assert all(isinstance(k, str) for k in cls.PATTERNS), msg
 
     @classmethod
     def accept(cls, url: str) -> bool:

--- a/downloaders.py
+++ b/downloaders.py
@@ -1,9 +1,9 @@
 import subprocess
-import urllib.request
-import re
+import regex
 
 from config import FFMPEG_DIR
 
+from commandline import Timestamp
 from metaclass import Descriptor
 from typing import List
 from pathlib import Path
@@ -24,10 +24,15 @@ class BaseDownloader(metaclass=Descriptor):
 
     @classmethod
     def accept(cls, url: str) -> bool:
-        return any(re.fullmatch(pattern, url) is not None for pattern in cls.PATTERNS)
+        return any(regex.fullmatch(pattern, url) is not None for pattern in cls.PATTERNS)
 
     @staticmethod
-    def download(uri: str, filename: Path) -> bool:
+    def download(
+        uri: str,
+        filename: Path,
+        start: Timestamp = None,
+        stop: Timestamp = None
+    ) -> bool:
         pass
 
 
@@ -43,20 +48,57 @@ class FallbackDownloader(BaseDownloader):
     ]
 
     @staticmethod
-    def download(url: str, filename: Path) -> bool:
-        return subprocess.run(
+    def download(
+        url: str,
+        filename: Path,
+        start: Timestamp = None,
+        stop: Timestamp = None
+    ) -> bool:
+        filename_ogg = filename.with_suffix(".ogg")
+        filename_tmp = filename.with_suffix(".tmp.ogg")
+        filename_ns = filename.with_suffix("")
+
+        cmd = (
             f"yt-dlp "
             f"-x "
             f"-i "
             f"-f ba "
-            f"-o {filename.with_suffix('')}.%(ext)s "
+            f"-o {filename_ns}.%(ext)s "
             f"--http-chunk-size 10M "
             f"--buffer-size 32K "
             f"--audio-format vorbis "
-            f"--audio-quality 160K "
+            f"--audio-quality 0 "
             f"--ffmpeg-location {FFMPEG_DIR} "
             f"{url}"
-        ).returncode == 0
+        )
+
+        if subprocess.run(cmd).returncode != 0:
+            return False
+
+        if start is None and stop is None:
+            return True
+
+        if None not in (start, stop) and start.value > stop.value:
+            return False
+
+        cmd = f"{FFMPEG_DIR}/ffmpeg.exe -hide_banner -loglevel error"
+
+        if start is not None:
+            cmd = f"{cmd} -ss {start.value}"
+
+        if stop is not None:
+            cmd = f"{cmd} -to {stop.value}"
+
+        cmd = f"{cmd} -i {filename_ogg} -c copy {filename_tmp}"
+        if subprocess.run(cmd).returncode != 0:
+            filename_ogg.unlink()
+            filename_tmp.unlink()
+            return False
+
+        filename_ogg.unlink()
+        filename_tmp.rename(filename_ogg)
+
+        return True
 
 
 # TODO(daniel): Verify that the url points to something playable

--- a/downloaders.py
+++ b/downloaders.py
@@ -35,19 +35,25 @@ class FallbackDownloader(BaseDownloader):
     PATTERNS: List[str] = [
         r"https://youtu.be/.*",
         r"https://(www\.)?youtube\.com/watch\?v=.*",
-        r"https://(www\.)?soundcloud\.com/.*"
+        r"https://(www\.)?soundcloud\.com/.*",
+        r"https://(www\.)?open\.spotify\.com/track/.*",
+        # TODO(daniel): Dailymotion download takes ages
+        #   r"https://(www\.)?dailymotion\.com/video/.*",
+        r"https://(www\.)?vimeo\.com/.*"
     ]
 
     @staticmethod
     def download(url: str, filename: Path) -> bool:
         return subprocess.run(
             f"yt-dlp "
+            f"-x "
+            f"-i "
             f"-f ba "
-            f"--ignore-errors "
-            f"--extract-audio "
+            f"-o {filename.with_suffix('')}.%(ext)s "
+            f"--http-chunk-size 10M "
+            f"--buffer-size 32K "
             f"--audio-format vorbis "
             f"--audio-quality 160K "
-            f"--output {filename.with_suffix('')}.%(ext)s "
             f"--ffmpeg-location {FFMPEG_DIR} "
             f"{url}"
         ).returncode == 0

--- a/downloaders.py
+++ b/downloaders.py
@@ -16,7 +16,7 @@ class BaseDownloader(metaclass=Descriptor):
     def validate(cls):
         if cls == BaseDownloader:
             return
-            
+
         msg = "PATTERNS must be a non-empty list of str"
         assert cls.PATTERNS, msg
         assert isinstance(cls.PATTERNS, list), msg

--- a/downloaders.py
+++ b/downloaders.py
@@ -1,7 +1,7 @@
 import subprocess
 import regex
 
-from config import FFMPEG_DIR
+from config import FFMPEG_DIR, FFMPEG_PATH
 
 from commandline import Timestamp
 from metaclass import Descriptor
@@ -78,10 +78,11 @@ class FallbackDownloader(BaseDownloader):
         if start is None and stop is None:
             return True
 
-        if None not in (start, stop) and start.value > stop.value:
+        if None not in (start, stop) and start.value >= stop.value:
+            print(f"[warn] Incorrect timestamp: {start.text}" >= {stop.text})
             return False
 
-        cmd = f"{FFMPEG_DIR}/ffmpeg.exe -hide_banner -loglevel error"
+        cmd = f"{FFMPEG_PATH} -hide_banner -loglevel error"
 
         if start is not None:
             cmd = f"{cmd} -ss {start.value}"

--- a/downloaders.py
+++ b/downloaders.py
@@ -53,11 +53,13 @@ class FallbackDownloader(BaseDownloader):
         ).returncode == 0
 
 
-class DirectDownloader(BaseDownloader):
-    PATTERNS: List[str] = [
-        r"https?://(www\.).*"
-    ]
-
-    @staticmethod
-    def download(url: str, filename: Path) -> bool:
-        return urllib.request.urlretrieve(url, str(filename))
+# TODO(daniel): Verify that the url points to something playable
+#
+# class DirectDownloader(BaseDownloader):
+#     PATTERNS: List[str] = [
+#         r"https?://(www\.).*"
+#     ]
+#
+#     @staticmethod
+#     def download(url: str, filename: Path) -> bool:
+#         return urllib.request.urlretrieve(url, str(filename))

--- a/downloaders.py
+++ b/downloaders.py
@@ -54,8 +54,8 @@ class FallbackDownloader(BaseDownloader):
         start: Timestamp = None,
         stop: Timestamp = None
     ) -> bool:
-        filename_ogg = filename.with_suffix(".ogg")
-        filename_tmp = filename.with_suffix(".tmp.ogg")
+        filename_ogg = filename.with_suffix(".opus")
+        filename_tmp = filename.with_suffix(".tmp.opus")
         filename_ns = filename.with_suffix("")
 
         cmd = (
@@ -66,7 +66,7 @@ class FallbackDownloader(BaseDownloader):
             f"-o {filename_ns}.%(ext)s "
             f"--http-chunk-size 10M "
             f"--buffer-size 32K "
-            f"--audio-format vorbis "
+            f"--audio-format opus "
             f"--audio-quality 0 "
             f"--ffmpeg-location {FFMPEG_DIR} "
             f"{url}"

--- a/downloaders.py
+++ b/downloaders.py
@@ -1,0 +1,54 @@
+import subprocess
+import urllib.request
+import re
+
+from config import FFMPEG_DIR
+
+from metaclass import Descriptor
+from typing import List
+from pathlib import Path
+from sclib import SoundcloudAPI
+
+
+class BaseDownloader(metaclass=Descriptor):
+    PATTERNS: List[str] = None
+
+    @classmethod
+    def accept(cls, url: str) -> bool:
+        return any(re.fullmatch(pattern, url) is not None for pattern in cls.PATTERNS)
+
+    @staticmethod
+    def download(uri: str, filename: Path) -> bool:
+        pass
+
+
+class FallbackDownloader(BaseDownloader):
+    PATTERNS: List[str] = [
+        r"https://youtu.be/.*",
+        r"https://(www\.)?youtube\.com/watch\?v=.*",
+        r"https://(www\.)?soundcloud\.com/.*"
+    ]
+
+    @staticmethod
+    def download(url: str, filename: Path) -> bool:
+        return subprocess.run(
+            f"yt-dlp "
+            f"-f ba "
+            f"--ignore-errors "
+            f"--extract-audio "
+            f"--audio-format vorbis "
+            f"--audio-quality 160K "
+            f"--output {filename.with_suffix('')}.%(ext)s "
+            f"--ffmpeg-location {FFMPEG_DIR} "
+            f"{url}"
+        ).returncode == 0
+
+
+class DirectDownloader(BaseDownloader):
+    PATTERNS: List[str] = [
+        r"https?://(www\.).*"
+    ]
+
+    @staticmethod
+    def download(url: str, filename: Path) -> bool:
+        return urllib.request.urlretrieve(url, str(filename))

--- a/metaclass.py
+++ b/metaclass.py
@@ -4,14 +4,23 @@ T = TypeVar("T")
 
 
 class Descriptor(type):
-    def __new__(meta, *args, **kwargs):
-        cls = super(Descriptor, meta).__new__(meta, *args, **kwargs)
+    def __new__(meta, name, bases, class_dict):
+        cls = super(Descriptor, meta).__new__(meta, name, bases, class_dict)
 
         def init(*_, **__):
             del _, __
             raise RuntimeError("Should not instantiate this")
+
         setattr(cls, "__init__", init)
+
+        if bases:
+            cls.validate()
+
         return cls
+
+    @classmethod
+    def validate(cls):
+        pass
 
     def get_instances(cls: T) -> List[T]:
         subclasses = []

--- a/metaclass.py
+++ b/metaclass.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TypeVar, List
 
 T = TypeVar("T")

--- a/metaclass.py
+++ b/metaclass.py
@@ -1,0 +1,27 @@
+from typing import TypeVar, List
+
+T = TypeVar("T")
+
+
+class Descriptor(type):
+    def __new__(meta, *args, **kwargs):
+        cls = super(Descriptor, meta).__new__(meta, *args, **kwargs)
+
+        def init(*_, **__):
+            del _, __
+            raise RuntimeError("Should not instantiate this")
+        setattr(cls, "__init__", init)
+        return cls
+
+    def get_instances(cls: T) -> List[T]:
+        subclasses = []
+
+        queue = [cls]
+        while queue:
+            current_class = queue.pop()
+            for child in current_class.__subclasses__():
+                if child not in subclasses:
+                    subclasses.append(child)
+                    queue.append(child)
+
+        return subclasses

--- a/util.py
+++ b/util.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import hashlib
+
+from config import THEMES_DIR, FFMPEG_PATH, DOWNLOAD_DIR
+
+from pathlib import Path
+from typing import Union
+from discord import FFmpegOpusAudio
+
+
+def get_theme_path(user: str) -> Path:
+    return (THEMES_DIR / user).with_suffix(".ogg")
+
+
+def get_download_path(uri: str) -> Path:
+    hash_value = hashlib.md5(uri.encode("utf8")).hexdigest()
+    return (DOWNLOAD_DIR / hash_value).with_suffix(".ogg")
+
+
+async def load_source(uri: Union[Path, str]) -> FFmpegOpusAudio:
+    return await FFmpegOpusAudio.from_probe(
+        source=str(uri),
+        executable=str(FFMPEG_PATH)
+    )

--- a/util.py
+++ b/util.py
@@ -27,12 +27,12 @@ class SongRequest:
 
 
 def get_theme_path(user: Member) -> Path:
-    return (THEMES_DIR / f"{user.name}#{user.discriminator}").with_suffix(".ogg")
+    return (THEMES_DIR / f"{user.name}#{user.discriminator}").with_suffix(".opus")
 
 
 def get_download_path(request: SongRequest) -> Path:
     hash_value = hashlib.md5(str(request).encode("utf8")).hexdigest()
-    return (DOWNLOAD_DIR / hash_value).with_suffix(".ogg")
+    return (DOWNLOAD_DIR / hash_value).with_suffix(".opus")
 
 
 def search_song(query: str) -> str:

--- a/util.py
+++ b/util.py
@@ -4,13 +4,22 @@ import hashlib
 
 from config import THEMES_DIR, FFMPEG_PATH, DOWNLOAD_DIR
 
+from dataclasses import dataclass
+from typing import Union, List
+from pytube import YouTube, Search
 from pathlib import Path
-from typing import Union
-from discord import FFmpegOpusAudio
+from discord import FFmpegOpusAudio, Member
+from downloaders import BaseDownloader
 
 
-def get_theme_path(user: str) -> Path:
-    return (THEMES_DIR / user).with_suffix(".ogg")
+@dataclass
+class LoadedSong:
+    uri: str
+    source: FFmpegOpusAudio
+
+
+def get_theme_path(user: Member) -> Path:
+    return (THEMES_DIR / f"{user.name}#{user.discriminator}").with_suffix(".ogg")
 
 
 def get_download_path(uri: str) -> Path:
@@ -18,8 +27,46 @@ def get_download_path(uri: str) -> Path:
     return (DOWNLOAD_DIR / hash_value).with_suffix(".ogg")
 
 
+def search_song(query: str) -> str:
+    results: List[YouTube]
+    results, _ = Search(query).fetch_and_parse()
+    if results:
+        return results[0].watch_url
+
+
+def can_download(uri: str):
+    return any(d.accept(uri) for d in BaseDownloader.get_instances())
+
+
 async def load_source(uri: Union[Path, str]) -> FFmpegOpusAudio:
     return await FFmpegOpusAudio.from_probe(
         source=str(uri),
         executable=str(FFMPEG_PATH)
     )
+
+
+async def download(uri: str, filename: Path = None, force: bool = False):
+    if not can_download(uri):
+        uri = search_song(uri)
+
+    if uri is None or not can_download(uri):
+        print("[warn] Requested song could not be found or is not supported")
+        return None
+
+    if filename is None:
+        filename = get_download_path(uri)
+
+    async def load_song():
+        source = await load_source(filename)
+        return LoadedSong(uri=uri, source=source)
+
+    if filename.is_file() and not force:
+        return await load_song()
+
+    for downloader in BaseDownloader.get_instances():
+        if downloader.accept(uri):
+            print(f"[info] Downloading via {downloader.__name__}")
+            if downloader.download(uri, filename):
+                break
+
+    return await load_song()

--- a/util.py
+++ b/util.py
@@ -38,7 +38,17 @@ def can_download(uri: str):
     return any(d.accept(uri) for d in BaseDownloader.get_instances())
 
 
-async def load_source(uri: Union[Path, str]) -> FFmpegOpusAudio:
+def resolve_uri(query: str) -> str:
+    if can_download(query):
+        return query
+    else:
+        return search_song(query)
+
+
+async def load_source(uri: Path) -> FFmpegOpusAudio:
+    if not uri.is_file():
+        return None
+
     return await FFmpegOpusAudio.from_probe(
         source=str(uri),
         executable=str(FFMPEG_PATH)
@@ -46,9 +56,7 @@ async def load_source(uri: Union[Path, str]) -> FFmpegOpusAudio:
 
 
 async def download(uri: str, filename: Path = None, force: bool = False):
-    if not can_download(uri):
-        uri = search_song(uri)
-
+    uri = resolve_uri(uri)
     if uri is None or not can_download(uri):
         print("[warn] Requested song could not be found or is not supported")
         return None


### PR DESCRIPTION
Most changes:
 - Add song caching
 - Download songs in background (when possible)
 - Replace Soundcloud and Youtube downloaders with a more reliable one
 - Add Vimeo and Spotify support
 - Switch to inheritance-style Discord API
 - Add function-like bot commands:
   - Number (float or integer)
   - Timestamp (minutes:seconds)
   - Strings (same as single double-quoted strings in python)
   - Identifiers

Changes to existing commands:
 - play[start: Timestamp, stop: Timestamp]
   - start: Timestamp (optional): Start time in song (default: beginning of song)
   - stop: Timestamp (optional): Stop time in song (default: end of song)
 - set_theme[start: Timestamp, stop: Timestamp] (alias settheme)
   - Same as play, but instead of playing the song it sets it as a login theme for the user

Examples:
- Play "trio da da da", but skip the first minute
```
play[start=1:00] trio da da da
```
- Play the first 30 seconds of "malhari"
```
play[stop=0:30] malhari
```
- Play the "my name is jeff" portion of the whole scene
```
settheme[start=0:20,stop=0:21] https://www.youtube.com/watch?v=6CKoBtMsdSw
```