### PR TITLE
Run directly as a module

### DIFF
--- a/assnouncer/__main__.py
+++ b/assnouncer/__main__.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+from assnouncer.assnouncer import Assnouncer
+
+ass = Assnouncer()
+ass.run(Path("token").read_text())

--- a/assnouncer/assnouncer.py
+++ b/assnouncer/assnouncer.py
@@ -213,7 +213,3 @@ class Assnouncer(Client):
             except (SyntaxError, TypeError) as e:
                 print(f"[warn] Command #{idx}: {e}")
 
-
-if __name__ == "__main__":
-    ass = Assnouncer()
-    ass.run(Path("token").read_text())


### PR DESCRIPTION
Allows users to run Assnouncer with `python -m assnouncer`.

Adds `__main__.py`